### PR TITLE
feat: add local-only scan option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,4 @@
 - `0.3.4` Various fixes. Scanning of built-in IDE tools.
 - `0.3.5` Improving description of some built-in IDE tools.
 - `0.3.6` Bug fix: tools without description were not working.
+- `0.3.7` Added `--local-only` option to skip external server access during scans and warn when verification is skipped.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ It then scans tool descriptions, both with local checks and by invoking Invarian
 
 Invariant Labs is collecting data for security research purposes (only about tool descriptions and how they change over time, not your user data). Don't use MCP-scan if you don't want to share your tools. Additionally, a unique, persistent, and anonymous ID is assigned to your scans for analysis. You can opt out of sending this information using the `--opt-out` flag.
 
+If you would like to skip all external network requests and perform only local checks, run the scan with the `--local-only` option. When this flag is used, the scan output highlights in red that no analysis server verification was performed.
+
 MCP-scan does not store or log any usage data, i.e. the contents and results of your MCP tool calls.
 
 ### Proxying
@@ -144,6 +146,7 @@ Options:
 --checks-per-server NUM       Number of checks to perform on each server (default: 1)
 --server-timeout SECONDS      Seconds to wait before timing out server connections (default: 10)
 --suppress-mcpserver-io BOOL  Suppress stdout/stderr from MCP servers (default: True)
+--local-only                  Skip all external server access during the scan
 ```
 
 #### proxy

--- a/src/mcp_scan/MCPScanner.py
+++ b/src/mcp_scan/MCPScanner.py
@@ -59,6 +59,7 @@ class MCPScanner:
         suppress_mcpserver_io: bool = True,
         opt_out: bool = False,
         include_built_in: bool = False,
+        local_only: bool = False,
         **kwargs: Any,
     ):
         logger.info("Initializing MCPScanner")
@@ -74,6 +75,7 @@ class MCPScanner:
         self.context_manager = None
         self.opt_out_of_identity = opt_out
         self.include_built_in = include_built_in
+        self.local_only = local_only
         logger.debug(
             "MCPScanner initialized with timeout: %d, checks_per_server: %d", server_timeout, checks_per_server
         )
@@ -212,9 +214,10 @@ class MCPScanner:
         logger.debug(f"Check changed: {path_result.path}, {path_result.path is None}")
         path_result.issues += self.check_server_changed(path_result)
         logger.debug(f"Verifying server path: {path_result.path}, {path_result.path is None}")
-        path_result = await analyze_scan_path(
-            path_result, base_url=self.base_url, opt_out_of_identity=self.opt_out_of_identity
-        )
+        if not self.local_only:
+            path_result = await analyze_scan_path(
+                path_result, base_url=self.base_url, opt_out_of_identity=self.opt_out_of_identity
+            )
         await self.emit("path_scanned", path_result)
         return path_result
 

--- a/src/mcp_scan/cli.py
+++ b/src/mcp_scan/cli.py
@@ -291,6 +291,12 @@ def main():
         help="Opts out of sending unique a unique user identifier with every scan.",
     )
     scan_parser.add_argument(
+        "--local-only",
+        default=False,
+        action="store_true",
+        help="Skip all external server access during the scan.",
+    )
+    scan_parser.add_argument(
         "--include-built-in",
         default=False,
         action="store_true",
@@ -527,6 +533,7 @@ async def run_scan_inspect(mode="scan", args=None):
         and args.push_key
         and hasattr(args, "email")
         and hasattr(args, "opt_out")
+        and not getattr(args, "local_only", False)
     ):
         await upload(result, args.control_server, args.push_key, args.email, args.opt_out)
 
@@ -534,6 +541,10 @@ async def run_scan_inspect(mode="scan", args=None):
         result = {r.path: r.model_dump(mode="json") for r in result}
         print(json.dumps(result, indent=2))
     else:
+        if getattr(args, "local_only", False):
+            rich.print(
+                "[bold red]Results have not been verified by the analysis server (--local-only).[/bold red]"
+            )
         print_scan_result(
             result,
             args.print_errors,


### PR DESCRIPTION
## Summary
- add --local-only flag to skip verification/upload network calls
- document local-only behaviour
- warn when analysis is skipped

## Testing
- `pre-commit run --files CHANGELOG.md README.md src/mcp_scan/cli.py` *(failed: command not found: pre-commit)*
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit (403 Forbidden))*
- `pip install hatchling` *(failed: Could not find a version that satisfies the requirement hatchling (403 Forbidden))*
- `pip install -e .` *(failed: Could not find a version that satisfies the requirement hatchling)*
- `pytest` *(ModuleNotFoundError: No module named 'mcp_scan')*

------
https://chatgpt.com/codex/tasks/task_e_68a64cda4e948324ae39441d2808cfc9