### PR TITLE
Warn when local-only scan skips analysis server

### DIFF
--- a/src/mcp_scan/cli.py
+++ b/src/mcp_scan/cli.py
@@ -547,6 +547,10 @@ async def run_scan_inspect(mode="scan", args=None):
             args.full_toxic_flows if hasattr(args, "full_toxic_flows") else False,
             mode == "inspect",
         )
+        if getattr(args, "local_only", False):
+            rich.print(
+                "[bold red]This scan was run with --local-only; results have not been analyzed by the analysis server.[/bold red]"
+            )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_cli_local_only.py
+++ b/tests/unit/test_cli_local_only.py
@@ -1,0 +1,29 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from mcp_scan.cli import run_scan_inspect
+
+
+@patch("mcp_scan.cli.print_scan_result")
+@patch("mcp_scan.cli.MCPScanner")
+def test_warns_when_local_only(mock_scanner_cls, mock_print, capsys):
+    scanner_instance = AsyncMock()
+    scanner_instance.scan.return_value = []
+    mock_scanner_cls.return_value.__aenter__.return_value = scanner_instance
+
+    args = SimpleNamespace(
+        local_only=True,
+        json=False,
+        print_errors=False,
+        full_toxic_flows=False,
+        control_server=None,
+        push_key=None,
+        email=None,
+        opt_out=False,
+    )
+
+    asyncio.run(run_scan_inspect(mode="scan", args=args))
+
+    captured = capsys.readouterr()
+    assert "analysis server" in captured.out.lower()


### PR DESCRIPTION
## Summary
- alert users when running `scan` with `--local-only` that results were not analyzed by the remote server
- add unit test for the new local-only warning

## Testing
- `PYTHONPATH=src pytest tests/unit/test_cli_local_only.py -q`
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_lazy_fixtures')*


------
https://chatgpt.com/codex/tasks/task_e_68a661449198832497a136851b47102c