### PR TITLE
feat: prompt before updating scan results

### DIFF
--- a/src/mcp_scan/MCPScanner.py
+++ b/src/mcp_scan/MCPScanner.py
@@ -221,7 +221,7 @@ class MCPScanner:
         await self.emit("path_scanned", path_result)
         return path_result
 
-    async def scan(self) -> list[ScanPathResult]:
+    async def scan(self, save_results: bool = True) -> list[ScanPathResult]:
         logger.info("Starting scan of %d paths", len(self.paths))
         if self.context_manager is not None:
             self.context_manager.disable()
@@ -236,16 +236,18 @@ class MCPScanner:
             result = [self.scan_path(path) for path in self.paths]
             result_awaited = await asyncio.gather(*result)
 
-        logger.debug("Saving storage file")
-        self.storage_file.save()
+        if save_results:
+            logger.debug("Saving storage file")
+            self.storage_file.save()
         logger.info("Scan completed successfully")
         return result_awaited
 
-    async def inspect(self) -> list[ScanPathResult]:
+    async def inspect(self, save_results: bool = True) -> list[ScanPathResult]:
         logger.info("Starting inspection of %d paths", len(self.paths))
         result = [self.scan_path(path, inspect_only=True) for path in self.paths]
         result_awaited = await asyncio.gather(*result)
-        logger.debug("Saving storage file")
-        self.storage_file.save()
+        if save_results:
+            logger.debug("Saving storage file")
+            self.storage_file.save()
         logger.info("Inspection completed successfully")
         return result_awaited

--- a/tests/unit/test_no_ask_update.py
+++ b/tests/unit/test_no_ask_update.py
@@ -1,0 +1,93 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from mcp_scan.cli import run_scan_inspect
+from mcp_scan.models import Issue, ScanPathResult
+
+
+@patch("mcp_scan.cli.input", return_value="Y")
+@patch("mcp_scan.cli.print_scan_result")
+@patch("mcp_scan.cli.MCPScanner")
+def test_update_prompt_yes(mock_scanner_cls, mock_print, mock_input):
+    scanner_instance = AsyncMock()
+    issue = Issue(code="W001", message="warn")
+    scanner_instance.scan.return_value = [ScanPathResult(path="p", servers=[], issues=[issue])]
+    scanner_instance.storage_file = MagicMock()
+    mock_scanner_cls.return_value.__aenter__.return_value = scanner_instance
+
+    args = SimpleNamespace(
+        no_ask_update=False,
+        json=False,
+        print_errors=False,
+        full_toxic_flows=False,
+        control_server=None,
+        push_key=None,
+        email=None,
+        opt_out=False,
+        local_only=False,
+    )
+
+    asyncio.run(run_scan_inspect(mode="scan", args=args))
+
+    mock_input.assert_called_once()
+    scanner_instance.storage_file.save.assert_called_once()
+    scanner_instance.scan.assert_called_with(save_results=False)
+
+
+@patch("mcp_scan.cli.input", return_value="N")
+@patch("mcp_scan.cli.print_scan_result")
+@patch("mcp_scan.cli.MCPScanner")
+def test_update_prompt_no(mock_scanner_cls, mock_print, mock_input):
+    scanner_instance = AsyncMock()
+    issue = Issue(code="E001", message="err")
+    scanner_instance.scan.return_value = [ScanPathResult(path="p", servers=[], issues=[issue])]
+    scanner_instance.storage_file = MagicMock()
+    mock_scanner_cls.return_value.__aenter__.return_value = scanner_instance
+
+    args = SimpleNamespace(
+        no_ask_update=False,
+        json=False,
+        print_errors=False,
+        full_toxic_flows=False,
+        control_server=None,
+        push_key=None,
+        email=None,
+        opt_out=False,
+        local_only=False,
+    )
+
+    asyncio.run(run_scan_inspect(mode="scan", args=args))
+
+    mock_input.assert_called_once()
+    scanner_instance.storage_file.save.assert_not_called()
+    scanner_instance.scan.assert_called_with(save_results=False)
+
+
+@patch("mcp_scan.cli.input")
+@patch("mcp_scan.cli.print_scan_result")
+@patch("mcp_scan.cli.MCPScanner")
+def test_no_ask_update_flag(mock_scanner_cls, mock_print, mock_input):
+    scanner_instance = AsyncMock()
+    issue = Issue(code="W001", message="warn")
+    scanner_instance.scan.return_value = [ScanPathResult(path="p", servers=[], issues=[issue])]
+    scanner_instance.storage_file = MagicMock()
+    mock_scanner_cls.return_value.__aenter__.return_value = scanner_instance
+
+    args = SimpleNamespace(
+        no_ask_update=True,
+        json=False,
+        print_errors=False,
+        full_toxic_flows=False,
+        control_server=None,
+        push_key=None,
+        email=None,
+        opt_out=False,
+        local_only=False,
+    )
+
+    asyncio.run(run_scan_inspect(mode="scan", args=args))
+
+    mock_input.assert_not_called()
+    scanner_instance.storage_file.save.assert_not_called()
+    scanner_instance.scan.assert_called_with(save_results=True)


### PR DESCRIPTION
## Summary
- default to asking before overwriting stored results when warnings or errors are detected
- add `--no-ask-update` flag to bypass the confirmation prompt
- test confirmation logic including flag to skip prompt

## Testing
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pre-commit run --files src/mcp_scan/cli.py tests/unit/test_no_ask_update.py` *(fails: command not found: pre-commit)*
- `PYTHONPATH=src pytest tests/unit/test_no_ask_update.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7a90525b48324bafb20dd7bc4cad9