### PR TITLE
feat: detect cross server tool and agent hijacking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@
 - `0.3.5` Improving description of some built-in IDE tools.
 - `0.3.6` Bug fix: tools without description were not working.
 - `0.3.7` Added `--local-only` option to skip external server access during scans.
+- `0.3.8` Detect cross-server references and agent hijacking in tool descriptions.

--- a/tests/unit/test_mcp_local_scan_server.py
+++ b/tests/unit/test_mcp_local_scan_server.py
@@ -43,18 +43,17 @@ def test_analyze_detects_prompt_injection():
         issues=[Issue(code="E001", message="Tool poisoning, prompt injection.", reference=(0, 0))]
     )
 
-
-def test_analyze_detects_secret_leak():
+def test_analyze_detects_cross_server_interaction():
     server.LLM_URL = "http://local-llm"
     result = _run_analyze(["no", "yes", "no"])
     assert result == AnalysisServerResponse(
-        issues=[Issue(code="E002", message="Sensitive data exfiltration.", reference=(0, 0))]
+        issues=[Issue(code="E002", message="Tool poisoning, cross server interaction.", reference=(0, 0))]
     )
 
 
-def test_analyze_detects_code_execution():
+def test_analyze_detects_agent_hijacking():
     server.LLM_URL = "http://local-llm"
     result = _run_analyze(["no", "no", "yes"])
     assert result == AnalysisServerResponse(
-        issues=[Issue(code="E003", message="Dangerous code execution request.", reference=(0, 0))]
+        issues=[Issue(code="E003", message="Tool poisoning, hijacking agent behavior.", reference=(0, 0))]
     )


### PR DESCRIPTION
## Summary
- scan for cross server tool references and agent hijacking instructions
- update unit tests for new E002 and E003 vulnerability codes
- document changes in changelog

## Testing
- `PYTHONPATH=src pytest tests/unit/test_mcp_local_scan_server.py::test_analyze_detects_cross_server_interaction tests/unit/test_mcp_local_scan_server.py::test_analyze_detects_agent_hijacking tests/unit/test_mcp_local_scan_server.py::test_analyze_detects_prompt_injection`
- `python -m ruff check src/mcp_local_scan_server/server.py tests/unit/test_mcp_local_scan_server.py`
- `PYTHONPATH=src pytest` *(failed: ModuleNotFoundError: No module named 'pytest_lazy_fixtures')*


------
https://chatgpt.com/codex/tasks/task_e_68a7b89b5f348324b5bbaaa11a45db77